### PR TITLE
Add chatroom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ rasa.db*
 results/
 models/
 snow_connector.py
+chatroom/

--- a/Dockerfile.chatroom
+++ b/Dockerfile.chatroom
@@ -1,0 +1,18 @@
+# docker build -t chatroom -f Dockerfile.chatroom
+# docker run --name chatroom -p 8080:3000 -d chatroom
+FROM node:14
+
+RUN node --version
+
+RUN git clone https://github.com/RasaHQ/chatroom.git
+
+WORKDIR /chatroom
+
+RUN npm install
+
+# replace default chatroom index.html
+COPY chatroom_handoff.html index.html
+
+EXPOSE 8080
+
+CMD [ "npm", "run-script", "serve" ]

--- a/Dockerfile.chatroom
+++ b/Dockerfile.chatroom
@@ -8,11 +8,14 @@ RUN git clone https://github.com/RasaHQ/chatroom.git
 
 WORKDIR /chatroom
 
-RUN npm install
+RUN curl -o- -L https://yarnpkg.com/install.sh | bash
+RUN yarn
 
 # replace default chatroom index.html
 COPY chatroom_handoff.html index.html
 
+RUN yarn build
+
 EXPOSE 8080
 
-CMD [ "npm", "run-script", "serve" ]
+CMD [ "yarn", "serve" ]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Here is an example of a conversation you can have with this bot:
   - [Testing the bot](#testing-the-bot)
   - [Rasa X Deployment](#rasa-x-deployment)
     - [Action Server Image](#action-server-image)
+  - [Notes on Chatroom](#notes-on-chatroom)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -317,3 +318,27 @@ docker run -p 5055:5055 <name of your custom image>:<tag of your custom image>
 Once you have confirmed that the container works as it should, you can push the container image to a registry with `docker push`
 
 It is recommended to use an[automated CI/CD process](https://rasa.com/docs/rasa/user-guide/setting-up-ci-cd) to keep your action server up to date in a production environment.
+
+## Notes on Chatroom
+
+If you want to try the transfer to another bot feature, you'll need to use Chatroom.  As of this writing, the main Scalable Minds chatroom [project](https://github.com/scalableminds/chatroom) has not done a PR with this new feature. Here are the steps to use the enhanced version with yarn:
+
+```
+git clone https://github.com/RasaHQ/chatroom.git
+cp chatroom_handoff.html chatroom/index.html
+cd chatroom
+yarn
+yarn build
+yarn serve
+```
+
+or with npm:
+
+```
+git clone https://github.com/RasaHQ/chatroom.git
+cp chatroom_handoff.html chatroom/index.html
+cd chatroom
+npm install
+npm build
+yarn serve
+```

--- a/README.md
+++ b/README.md
@@ -321,27 +321,27 @@ It is recommended to use an[automated CI/CD process](https://rasa.com/docs/rasa/
 
 ## Notes on Chatroom
 
-If you want to try the transfer to another bot feature, you'll need to use Chatroom.  As of this writing, the main Scalable Minds chatroom [project](https://github.com/scalableminds/chatroom) has not done a PR with this new feature.
+If you want to try the transfer to another bot feature, you'll need to use Chatroom.  As of this writing, the main Scalable Minds chatroom [project](https://github.com/scalableminds/chatroom) has not included this feature so you will need to build from a branch. The following docker commands will build an image from the new Chatroom and run it.
 
 ```
-docker build -t chatroom -f Dockerfile.chatroom
-docker run --name chatroom -p 8080:3000 -d chatroom
+docker build -t chatroom -f Dockerfile.chatroom .
+docker run --name chatroom -p 8080:8080 -d chatroom
 ```
 
-Here's an example docker-compose.yml for this image. Note that the `INITIAL_RASA_ENDPOINT` environment variable is not yet implemented. This is currently hard coded in `chatroom_handoff.html`.
+The the `docker-compose.yml` below, you can start chatroom with `docker-compose up -d`
+
+Here's an example docker-compose.yml for this image. Note that the initial Rasa endpoint URL is hard coded in `chatroom_handoff.html`.
 
 ```
 version: "3.4"
 
 services:
-  rasa-x:
+  chatroom:
     image: chatroom
     build:
       context: ./
       dockerfile: Dockerfile.chatroom
-    environment:
-      - INITIAL_RASA_ENDPOINT=http://helpdesk-assistant.rasa.com:5005
-    expose:
+    ports:
       - "8080:8080"
-    command: [ "npm", "run-script", "serve" ]
+    command: [ "yarn", "serve" ]
 ```

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ docker run --name chatroom -p 8080:8080 -d chatroom
 
 From the `docker-compose.yml` below, you can start chatroom with `docker-compose up -d`
 
-Here's an example docker-compose.yml for this image. Note that the initial Rasa endpoint URL is hard coded in `chatroom_handoff.html`.
+Here's an example docker-compose.yml for this image. Note that the initial Rasa endpoint URL is hard coded in `chatroom_handoff.html`; to use your locally running bot, point it to `http://localhost:5005`.
 
 ```
 version: "3.4"

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ It is recommended to use an[automated CI/CD process](https://rasa.com/docs/rasa/
 
 ## Notes on Chatroom
 
-If you want to try the transfer to another bot feature, you'll need to use Chatroom.  As of this writing, the main Scalable Minds chatroom [project](https://github.com/scalableminds/chatroom) has not included this feature so you will need to build from a branch. The following docker commands will build an image from the new Chatroom and run it.
+If you want to try the transfer to another bot feature, you'll need to use Chatroom.  As of this writing, the main Scalable Minds chatroom [project](https://github.com/scalableminds/chatroom) has not included this feature so you will need to build from a fork. The following docker commands will build an image from the adapted Chatroom and run it.
 
 ```
 docker build -t chatroom -f Dockerfile.chatroom .

--- a/README.md
+++ b/README.md
@@ -321,24 +321,27 @@ It is recommended to use an[automated CI/CD process](https://rasa.com/docs/rasa/
 
 ## Notes on Chatroom
 
-If you want to try the transfer to another bot feature, you'll need to use Chatroom.  As of this writing, the main Scalable Minds chatroom [project](https://github.com/scalableminds/chatroom) has not done a PR with this new feature. Here are the steps to use the enhanced version with yarn:
+If you want to try the transfer to another bot feature, you'll need to use Chatroom.  As of this writing, the main Scalable Minds chatroom [project](https://github.com/scalableminds/chatroom) has not done a PR with this new feature.
 
 ```
-git clone https://github.com/RasaHQ/chatroom.git
-cp chatroom_handoff.html chatroom/index.html
-cd chatroom
-yarn
-yarn build
-yarn serve
+docker build -t chatroom -f Dockerfile.chatroom
+docker run --name chatroom -p 8080:3000 -d chatroom
 ```
 
-or with npm:
+Here's an example docker-compose.yml for this image. Note that the `INITIAL_RASA_ENDPOINT` environment variable is not yet implemented. This is currently hard coded in `chatroom_handoff.html`.
 
 ```
-git clone https://github.com/RasaHQ/chatroom.git
-cp chatroom_handoff.html chatroom/index.html
-cd chatroom
-npm install
-npm build
-yarn serve
+version: "3.4"
+
+services:
+  rasa-x:
+    image: chatroom
+    build:
+      context: ./
+      dockerfile: Dockerfile.chatroom
+    environment:
+      - INITIAL_RASA_ENDPOINT=http://helpdesk-assistant.rasa.com:5005
+    expose:
+      - "8080:8080"
+    command: [ "npm", "run-script", "serve" ]
 ```

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ docker build -t chatroom -f Dockerfile.chatroom .
 docker run --name chatroom -p 8080:8080 -d chatroom
 ```
 
-The the `docker-compose.yml` below, you can start chatroom with `docker-compose up -d`
+From the `docker-compose.yml` below, you can start chatroom with `docker-compose up -d`
 
 Here's an example docker-compose.yml for this image. Note that the initial Rasa endpoint URL is hard coded in `chatroom_handoff.html`.
 

--- a/chatroom_handoff.html
+++ b/chatroom_handoff.html
@@ -4,10 +4,10 @@
 <body>
   <div class="chat-container"></div>
 
-  <script src="http://127.0.0.1:8080/dist/Chatroom.js"/></script>
+  <script src="./dist/Chatroom.js"></script>
   <script type="text/javascript">
     var chatroom = new window.Chatroom({
-      host: "http://localhost:5005",
+      host: "http://helpdesk-assistant.rasa.com:5005",
       title: "Helpdesk Assistant",
       container: document.querySelector(".chat-container"),
       welcomeMessage: "Hi, how may I help you?"

--- a/chatroom_handoff.html
+++ b/chatroom_handoff.html
@@ -1,5 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
 <head>
-  <link rel="stylesheet" href="http://127.0.0.1:8080/dist/Chatroom.css" />
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="./dist/Chatroom.css" />
+  <link rel="stylesheet" type="text/css" href="./index.css">
 </head>
 <body>
   <div class="chat-container"></div>
@@ -7,7 +12,7 @@
   <script src="./dist/Chatroom.js"></script>
   <script type="text/javascript">
     var chatroom = new window.Chatroom({
-      host: "http://helpdesk-assistant.rasa.com:5005",
+      host: "http://helpdesk-assistant.rasa.com",
       title: "Helpdesk Assistant",
       container: document.querySelector(".chat-container"),
       welcomeMessage: "Hi, how may I help you?"
@@ -17,3 +22,4 @@
     chatroom.openChat();
   </script>
 </body>
+</html>


### PR DESCRIPTION
This PR adds a `Dockerfile.chatroom` that will build a Docker image contain the new Chatroom with handoff support. It also documents, in a new README.md section, how to run a container on this image to with Chatroom.