### PR TITLE
replace setenv commands

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,7 +26,7 @@ jobs:
         run: docker pull rasa/helpdesk-assistant:latest || true
 
       - name: Set Build ID from run ID and number
-        run: echo ::set-env name=BUILD_NUMBER::$GITHUB_RUN_NUMBER-$GITHUB_RUN_ID
+        run: echo "BUILD_NUMBER=$GITHUB_RUN_NUMBER-$GITHUB_RUN_ID" >> $GITHUB_ENV
 
       - name: Build latest${{ matrix.image.tag_ext }} Docker image
         run: docker build . --tag rasa/helpdesk-assistant:latest --tag rasa/helpdesk-assistant:run$BUILD_NUMBER --cache-from rasa/helpdesk-assistant:latest


### PR DESCRIPTION
Replace deprecated set-env commands in CI because of https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/