### PR TITLE
Use env vars more & split train/test

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,13 +5,18 @@ on:
     - master
     paths:
     - 'actions/**'
+    - '.github/workflows/continuous-integration.yml'
 
 jobs:
   docker:
     name: Build Action Server Docker Image
     runs-on: ubuntu-latest
     env:
+      RASA_SDK_VERS: 2.1.2
+      DOCKER_IMAGE_TAG: latest
       DOCKERHUB_USERNAME: oakela
+      DOCKER_IMAGE_NAME: rasa/helpdesk-assistant
+      REQUIREMENTS_FILE: 'actions/requirements.txt'
     steps:
       - name: Checkout git repository 🕝
         uses: actions/checkout@v2
@@ -19,9 +24,9 @@ jobs:
         uses: RasaHQ/rasa-action-server-gha@master
         with:
           actions_directory: 'actions'
-          requirements_file: 'actions/requirements-actions.txt'
+          requirements_file: ${{ env.REQUIREMENTS_FILE }}
           docker_registry_login: ${{ env.DOCKERHUB_USERNAME }}
           docker_registry_password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          docker_image_name: 'rasa/helpdesk-assistant'
-          docker_image_tag: 'latest'
-          rasa_sdk_version: '2.1.2'
+          docker_image_name: ${{ env.DOCKER_IMAGE_NAME }}
+          docker_image_tag: ${{ env.DOCKER_IMAGE_TAG }}
+          rasa_sdk_version: ${{ env.RASA_SDK_VERS }}

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -43,25 +43,44 @@ jobs:
       working-directory: ${{ github.workspace }}
       run: |
         make types
-  training-testing:
-    name: Training and Testing
+  training:
+    name: Training Model
     runs-on: ubuntu-latest
     needs: [lint-testing, type-testing]
+    env:
+      RASA_VERSION: 2.1.3
     steps:
       - uses: actions/checkout@v1
       - id: files
         uses: jitterbit/get-changed-files@v1
-      - name: set_training
+      - name: Did Training Data Change
         if: |
             contains(  steps.files.outputs.all, 'data/' )
             || contains(  steps.files.outputs.all, 'config.yml' )
             || contains(  steps.files.outputs.all, 'domain.yml' )
+            || contains(  steps.files.outputs.all, '.github/workflows/build-model.yml' )
         run: echo "RUN_TRAINING=true" >> $GITHUB_ENV
-      - name: Rasa Train and Test GitHub Action
+      - name: Rasa Train
         if: env.RUN_TRAINING == 'true'
         uses: RasaHQ/rasa-train-test-gha@main
         with:
-          rasa_version: '2.1.3'
+          rasa_version: ${{ env.RASA_VERSION }}
+          rasa_test: false
+          data_validate: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+  test-model:
+    name: Test Model
+    runs-on: ubuntu-latest
+    needs: [training]
+    env:
+      RASA_VERSION: 2.1.3
+    steps:
+      - uses: actions/checkout@v1
+      - name: Rasa Train and Test GitHub Action
+        uses: RasaHQ/rasa-train-test-gha@main
+        with:
+          rasa_version: ${{ env.RASA_VERSION }}
+          rasa_train: false
           test_type: all
           data_validate: true
           cross_validation: true
@@ -73,3 +92,4 @@ jobs:
         with:
           name: model
           path: models
+

--- a/.github/workflows/lint_and_test_pr.yml
+++ b/.github/workflows/lint_and_test_pr.yml
@@ -41,25 +41,44 @@ jobs:
       working-directory: ${{ github.workspace }}
       run: |
         make types
-  training-testing:
-    name: Training and Testing
+  training:
+    name: Training Model
     runs-on: ubuntu-latest
     needs: [lint-testing, type-testing]
+    env:
+      RASA_VERSION: 2.1.3
     steps:
       - uses: actions/checkout@v1
       - id: files
         uses: jitterbit/get-changed-files@v1
-      - name: set_training
+      - name: Did Training Data Change
         if: |
             contains(  steps.files.outputs.all, 'data/' )
             || contains(  steps.files.outputs.all, 'config.yml' )
             || contains(  steps.files.outputs.all, 'domain.yml' )
+            || contains(  steps.files.outputs.all, '.github/workflows/build-model.yml' )
         run: echo "RUN_TRAINING=true" >> $GITHUB_ENV
-      - name: Rasa Train and Test GitHub Action
+      - name: Rasa Train
         if: env.RUN_TRAINING == 'true'
         uses: RasaHQ/rasa-train-test-gha@main
         with:
-          rasa_version: '2.1.3'
+          rasa_version: ${{ env.RASA_VERSION }}
+          rasa_test: false
+          data_validate: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+  test-model:
+    name: Test Model
+    runs-on: ubuntu-latest
+    needs: [training]
+    env:
+      RASA_VERSION: 2.1.3
+    steps:
+      - uses: actions/checkout@v1
+      - name: Rasa Train and Test GitHub Action
+        uses: RasaHQ/rasa-train-test-gha@main
+        with:
+          rasa_version: ${{ env.RASA_VERSION }}
+          rasa_train: false
           test_type: all
           data_validate: true
           cross_validation: true

--- a/.github/workflows/lint_and_test_pr.yml
+++ b/.github/workflows/lint_and_test_pr.yml
@@ -41,13 +41,12 @@ jobs:
       working-directory: ${{ github.workspace }}
       run: |
         make types
-  training:
-    name: Training Model
+  training-testing:
+    name: Training and Testing
     runs-on: ubuntu-latest
     needs: [lint-testing, type-testing]
     env:
       RASA_VERSION: 2.1.3
-      RUN_TRAINING: false
     steps:
       - uses: actions/checkout@v1
       - id: files
@@ -58,28 +57,11 @@ jobs:
             || contains(  steps.files.outputs.all, 'config.yml' )
             || contains(  steps.files.outputs.all, 'domain.yml' )
         run: echo "RUN_TRAINING=true" >> $GITHUB_ENV
-      - name: Rasa Train
+      - name: Rasa Train and Test GitHub Action
         if: env.RUN_TRAINING == 'true'
         uses: RasaHQ/rasa-train-test-gha@main
         with:
           rasa_version: ${{ env.RASA_VERSION }}
-          rasa_test: false
-          data_validate: true
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-  test-model:
-    name: Test Model
-    if: env.RUN_TRAINING == 'true'
-    runs-on: ubuntu-latest
-    needs: [training]
-    env:
-      RASA_VERSION: 2.1.3
-    steps:
-      - uses: actions/checkout@v1
-      - name: Rasa Train and Test GitHub Action
-        uses: RasaHQ/rasa-train-test-gha@main
-        with:
-          rasa_version: ${{ env.RASA_VERSION }}
-          rasa_train: false
           test_type: all
           data_validate: true
           cross_validation: true

--- a/.github/workflows/lint_and_test_pr.yml
+++ b/.github/workflows/lint_and_test_pr.yml
@@ -47,6 +47,7 @@ jobs:
     needs: [lint-testing, type-testing]
     env:
       RASA_VERSION: 2.1.3
+      RUN_TRAINING: false
     steps:
       - uses: actions/checkout@v1
       - id: files
@@ -56,7 +57,6 @@ jobs:
             contains(  steps.files.outputs.all, 'data/' )
             || contains(  steps.files.outputs.all, 'config.yml' )
             || contains(  steps.files.outputs.all, 'domain.yml' )
-            || contains(  steps.files.outputs.all, '.github/workflows/build-model.yml' )
         run: echo "RUN_TRAINING=true" >> $GITHUB_ENV
       - name: Rasa Train
         if: env.RUN_TRAINING == 'true'
@@ -68,6 +68,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
   test-model:
     name: Test Model
+    if: env.RUN_TRAINING == 'true'
     runs-on: ubuntu-latest
     needs: [training]
     env:


### PR DESCRIPTION
What do you think about these changes to the workflow?  Use env variables for a few more setting and split test/train into two separate steps.

I like the visibility in the GH actions of know when training is done vs. testing since both of these steps can take a long time.