### PR TITLE
change default branch name to main

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,7 +2,7 @@ name: Continuous Integration
 on:
   push:
     branches:
-    - master
+    - main
     paths:
     - 'actions/**'
 
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout git repository 🕝
         uses: actions/checkout@v2
       - name: Build Actions Server Image
-        uses: RasaHQ/rasa-action-server-gha@master
+        uses: RasaHQ/rasa-action-server-gha@main
         with:
           actions_directory: 'actions'
           requirements_file: 'actions/requirements-actions.txt'

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: 3.6
     - name: Install dependencies
       run: |
-        python -m pip install -U 'pip<20'
+        python -m pip install -U pip
         pip install -r requirements-dev.txt
     - name: Code Formatting Tests
       working-directory: ${{ github.workspace }}
@@ -37,7 +37,7 @@ jobs:
         python-version: 3.6
     - name: Install dependencies
       run: |
-        python -m pip install -U 'pip<20'
+        python -m pip install -U pip
         pip install -r requirements-dev.txt
     - name: Type Checking
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -2,7 +2,7 @@ name: Lint and Test
 on:
   push:
     branches:
-      - master
+      - main
     paths-ignore:
     - "README.md"
     - "Makefile"
@@ -68,8 +68,8 @@ jobs:
           publish_summary: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload model
-        if: github.ref == 'refs/heads/master'
-        uses: actions/upload-artifact@master
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@main
         with:
           name: model
           path: models

--- a/.github/workflows/lint_and_test_pr.yml
+++ b/.github/workflows/lint_and_test_pr.yml
@@ -66,8 +66,8 @@ jobs:
           publish_summary: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload model
-        if: github.ref == 'refs/heads/master'
-        uses: actions/upload-artifact@master
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@main
         with:
           name: model
           path: models

--- a/.github/workflows/lint_and_test_pr.yml
+++ b/.github/workflows/lint_and_test_pr.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: 3.6
     - name: Install dependencies
       run: |
-        python -m pip install -U 'pip<20'
+        python -m pip install -U pip
         pip install -r requirements-dev.txt
     - name: Code Formatting Tests
       working-directory: ${{ github.workspace }}
@@ -35,7 +35,7 @@ jobs:
         python-version: 3.6
     - name: Install dependencies
       run: |
-        python -m pip install -U 'pip<20'
+        python -m pip install -U pip
         pip install -r requirements-dev.txt
     - name: Type Checking
       working-directory: ${{ github.workspace }}


### PR DESCRIPTION
Change workflows to work on `main` branch. 

Also updated the github actions we use as their default branches' names were changed: 
* https://github.com/actions/upload-artifact
* https://github.com/RasaHQ/rasa-action-server-gha
* Chatroom hasn't updated their default branch name yet, so links to that are still unchanged.

Still to do: 
- Update target branch of any deployed instances that connect to this bot
- Update any docs/blogs that link to the helpdesk assistant