### PR TITLE
Added required_slots field to form definitions.

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,4 +24,4 @@ jobs:
           docker_registry_password: ${{ secrets.DOCKERHUB_PASSWORD }}
           docker_image_name: 'rasa/helpdesk-assistant'
           docker_image_tag: 'latest'
-          rasa_sdk_version: '2.1.2'
+          rasa_sdk_version: '2.8.0'

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -61,7 +61,7 @@ jobs:
         if: env.RUN_TRAINING == 'true'
         uses: RasaHQ/rasa-train-test-gha@main
         with:
-          rasa_version: '2.1.3'
+          rasa_version: '2.8.0'
           test_type: all
           data_validate: true
           cross_validation: true

--- a/.github/workflows/lint_and_test_pr.yml
+++ b/.github/workflows/lint_and_test_pr.yml
@@ -59,7 +59,7 @@ jobs:
         if: env.RUN_TRAINING == 'true'
         uses: RasaHQ/rasa-train-test-gha@main
         with:
-          rasa_version: '2.1.3'
+          rasa_version: '2.8.0'
           test_type: all
           data_validate: true
           cross_validation: true

--- a/domain.yml
+++ b/domain.yml
@@ -121,57 +121,59 @@ responses:
 
 forms:
   open_incident_form:
-    email:
-      - type: from_entity
-        entity: email
-      - type: from_intent
-        intent: affirm
-        value: true
-      - type: from_intent
-        intent: deny
-        value: false
-    priority:
-      - type: from_entity
-        entity: priority
-    problem_description:
-      - type: from_text
-        not_intent:
-          - incident_status
-          - bot_challenge
-          - help
-          - affirm
-          - deny
-    incident_title:
-      - type: from_trigger_intent
-        intent: password_reset
-        value: "Problem resetting password"
-      - type: from_trigger_intent
-        intent: problem_email
-        value: "Problem with email"
-      - type: from_text
-        not_intent:
-          - incident_status
-          - bot_challenge
-          - help
-          - affirm
-          - deny
-    confirm:
-      - type: from_intent
-        intent: affirm
-        value: true
-      - type: from_intent
-        intent: deny
-        value: false
+    required_slots:
+      email:
+        - type: from_entity
+          entity: email
+        - type: from_intent
+          intent: affirm
+          value: true
+        - type: from_intent
+          intent: deny
+          value: false
+      priority:
+        - type: from_entity
+          entity: priority
+      problem_description:
+        - type: from_text
+          not_intent:
+            - incident_status
+            - bot_challenge
+            - help
+            - affirm
+            - deny
+      incident_title:
+        - type: from_trigger_intent
+          intent: password_reset
+          value: "Problem resetting password"
+        - type: from_trigger_intent
+          intent: problem_email
+          value: "Problem with email"
+        - type: from_text
+          not_intent:
+            - incident_status
+            - bot_challenge
+            - help
+            - affirm
+            - deny
+      confirm:
+        - type: from_intent
+          intent: affirm
+          value: true
+        - type: from_intent
+          intent: deny
+          value: false
   incident_status_form:
-    email:
-      - type: from_entity
-        entity: email
-      - type: from_intent
-        intent: affirm
-        value: true
-      - type: from_intent
-        intent: deny
-        value: false
+    required_slots:
+      email:
+        - type: from_entity
+          entity: email
+        - type: from_intent
+          intent: affirm
+          value: true
+        - type: from_intent
+          intent: deny
+          value: false
 
 actions:
 - action_ask_email

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-rasa~=2.0.0
-rasa-sdk~=2.0.0  # if you change this, make sure to change the Dockerfile to match
+rasa~=2.8.0
+rasa-sdk~=2.8.0  # if you change this, make sure to change the Dockerfile to match
 -r actions/requirements-actions.txt


### PR DESCRIPTION
Currently the form definitions in the domain.yml do not use the `required_slots` key. Not using the key was marked as deprecated in Rasa 2.6. As we move to 3.0 and start removing deprecated behaviors, not using the `required_slots` keys will cause training to fail on YAML validation.

This PR adds the `required_slots` key to all form definitions in the domain.yml. This should not change the behavior of the bot.